### PR TITLE
dc_impl::get_current_process_hash(): <unistd.h> is required for getpid()

### DIFF
--- a/src/graphlab/rpc/get_current_process_hash.cpp
+++ b/src/graphlab/rpc/get_current_process_hash.cpp
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <errno.h>
 #include <libproc.h>
+#include <unistd.h>
 #endif
 namespace graphlab {
 namespace dc_impl {


### PR DESCRIPTION
`getpid()` requires including `unistd.h`. This is at least required with XCode 5.
