### PR TITLE
Minor fix in a library name in README instructions for linking GraphLab.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ run make install . This will install the following:
     
 Once you have installed GraphLab you can compile your program by running:
 
-    g++ -pthread -lz -ltcmalloc -levent -levent_pthread -ljson -lboost_filesystem -lboost_program_options -lboost_system -lboost_iostreams -lboost_date_time -lhdfs -lgraphlab hello_world.cpp 
+    g++ -pthread -lz -ltcmalloc -levent -levent_pthreads -ljson -lboost_filesystem -lboost_program_options -lboost_system -lboost_iostreams -lboost_date_time -lhdfs -lgraphlab hello_world.cpp 
   
   
 


### PR DESCRIPTION
libevent_pthreads was missing the trailing s.
