### PR TITLE
disabled dynamic graphs because of saving vertex problem. Anyone who is ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ include_directories(
 # set link path
 link_directories(${GraphLab_SOURCE_DIR}/deps/local/lib)
 
-add_definitions(-DUSE_DYNAMIC_LOCAL_GRAPH)
+#add_definitions(-DUSE_DYNAMIC_LOCAL_GRAPH)
 
 if(NO_OPENMP)
   set(OPENMP_C_FLAGS "")


### PR DESCRIPTION
...interested in testing dynamic graphs should enabled them manually by uncommenting this line
