### PR TITLE
Minor fix in engines doc: elapsed_time -> elapsed_seconds

### DIFF
--- a/src/graphlab/engine/async_consistent_engine.hpp
+++ b/src/graphlab/engine/async_consistent_engine.hpp
@@ -177,7 +177,7 @@ namespace graphlab {
    *   graphlab::async_consistent_engine<pagerank_vprog> engine(dc, graph, clopts);
    *   engine.signal_all();
    *   engine.start();
-   *   std::cout << "Runtime: " << engine.elapsed_time();
+   *   std::cout << "Runtime: " << engine.elapsed_seconds();
    *   graphlab::mpi_tools::finalize();
    * }
    * \endcode

--- a/src/graphlab/engine/synchronous_engine.hpp
+++ b/src/graphlab/engine/synchronous_engine.hpp
@@ -162,7 +162,7 @@ namespace graphlab {
    *   graphlab::synchronous_engine<pagerank_vprog> engine(dc, graph, clopts);
    *   engine.signal_all();
    *   engine.start();
-   *   std::cout << "Runtime: " << engine.elapsed_time();
+   *   std::cout << "Runtime: " << engine.elapsed_seconds();
    *   graphlab::mpi_tools::finalize();
    * }
    * \endcode

--- a/src/graphlab/engine/warp_engine.hpp
+++ b/src/graphlab/engine/warp_engine.hpp
@@ -150,7 +150,7 @@ namespace warp {
    *   engine.set_update_function(pagerank);
    *   engine.signal_all();
    *   engine.start();
-   *   std::cout << "Runtime: " << engine.elapsed_time();
+   *   std::cout << "Runtime: " << engine.elapsed_seconds();
    *   graphlab::mpi_tools::finalize();
    * }
    * \endcode


### PR DESCRIPTION
Maybe the method's name was modified at some time.
