### PR TITLE
Fix broken </tt> tag on the clustering docs

### DIFF
--- a/toolkits/clustering/clustering.dox
+++ b/toolkits/clustering/clustering.dox
@@ -199,7 +199,7 @@ For instance:
 4 1 
 \endverbatim
 
-<tt>--id</tt> can be used with <tt>--sparse/tt>.
+<tt>--id</tt> can be used with <tt>--sparse</tt>.
 
 \subsection clustering_kmeans_edge_data Adding Pairwise Reward
 


### PR DESCRIPTION
There is a missing '<' in the clustering documentation for the
--id option [1] which makes the output look like this:

```
–id can be used with –sparse/tt>.
```

This patch adds the missing symbol making it properly display
as:

```
–id can be used with –sparse.
```

NOTE: This is a single character change better viewed with the
`--word-diff` option.

http://docs.graphlab.org/clustering.html#clustering_kmeans_id
