### PR TITLE
Add support for manually disabling tcmalloc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,25 +219,26 @@ foreach(blib ${Boost_LIBRARIES})
 endforeach()
 message(STATUS "Boost Shared libs: " ${Boost_SHARED_LIBRARIES})
 
+if(NOT NO_TCMALLOC)
+    if(APPLE)
+    set (tcmalloc_shared "--enable-shared=yes")
+    else()
+    set (tcmalloc_shared "--enable-shared=no")
+    endif()
 
-if(APPLE)
-  set (tcmalloc_shared "--enable-shared=yes")
-else()
-  set (tcmalloc_shared "--enable-shared=no")
+    # TCMalloc  ===================================================================
+    # We use tcmalloc for improved memory allocation performance
+    ExternalProject_Add(libtcmalloc
+    PREFIX ${GraphLab_SOURCE_DIR}/deps/tcmalloc
+    URL http://gperftools.googlecode.com/files/gperftools-2.0.tar.gz
+    URL_MD5 13f6e8961bc6a26749783137995786b6
+    PATCH_COMMAND patch -N -p0 -i ${GraphLab_SOURCE_DIR}/patches/tcmalloc.patch || true
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure --enable-frame-pointers --prefix=<INSTALL_DIR> ${tcmalloc_shared}
+    INSTALL_DIR ${GraphLab_SOURCE_DIR}/deps/local)
+    #link_libraries(tcmalloc)
+    set(TCMALLOC-FOUND 1)
+    add_definitions(-DHAS_TCMALLOC)
 endif()
-
-# TCMalloc  ===================================================================
-# We use tcmalloc for improved memory allocation performance
-ExternalProject_Add(libtcmalloc
-  PREFIX ${GraphLab_SOURCE_DIR}/deps/tcmalloc
-  URL http://gperftools.googlecode.com/files/gperftools-2.0.tar.gz
-  URL_MD5 13f6e8961bc6a26749783137995786b6
-  PATCH_COMMAND patch -N -p0 -i ${GraphLab_SOURCE_DIR}/patches/tcmalloc.patch || true
-  CONFIGURE_COMMAND <SOURCE_DIR>/configure --enable-frame-pointers --prefix=<INSTALL_DIR> ${tcmalloc_shared}
-  INSTALL_DIR ${GraphLab_SOURCE_DIR}/deps/local)
-#link_libraries(tcmalloc)
-set(TCMALLOC-FOUND 1)
-add_definitions(-DHAS_TCMALLOC)
 
 
 
@@ -486,11 +487,10 @@ macro(requires_core_deps NAME)
   target_link_libraries(${NAME}
     ${Boost_LIBRARIES}
     z
-    tcmalloc
     event event_pthreads
     zookeeper_mt
     json)
-  add_dependencies(${NAME} boost libevent libjson zookeeper libtcmalloc)
+  add_dependencies(${NAME} boost libevent libjson zookeeper)
   if(MPI_FOUND)
     target_link_libraries(${NAME} ${MPI_LIBRARY} ${MPI_EXTRA_LIBRARY})
   endif(MPI_FOUND)
@@ -498,6 +498,10 @@ macro(requires_core_deps NAME)
     target_link_libraries(${NAME} hdfs ${JAVA_JVM_LIBRARY})
     add_dependencies(${NAME} hadoop)
   endif(HADOOP_FOUND)
+  if(NOT NO_TCMALLOC)
+    target_link_libraries(${NAME} tcmalloc)
+    add_dependencies(${NAME} libtcmalloc)
+  endif()
 endmacro(requires_core_deps)
 
 

--- a/configure
+++ b/configure
@@ -30,6 +30,8 @@ function print_help {
   echo
   echo "  --no_jvm            Disable JVM features including HDFS integration."
   echo
+  echo "  --no_tcmalloc       Disable using tcmalloc instead of malloc."
+  echo
   echo "  --experimental      Turns on undocumented experimental capabilities. "
   echo
   echo "  --c++11             Turns on C++11 experimental features. "
@@ -120,6 +122,7 @@ GRAPHLAB_HOME=$PWD
 DEPS_PREFIX=$PWD/deps/local
 NO_OPENMP=false
 NO_MPI=false
+NO_TCMALLOC=false
 CPP11=false
 VID32=false
 CFLAGS=""
@@ -147,6 +150,7 @@ while [ $# -gt 0 ]
     --cleanup)              run_cleanup=1 ;;
     --no_openmp)            no_openmp=1 ;;
     --no_mpi)               no_mpi=1 ;;
+    --no_tcmalloc)          no_tcmalloc=1 ;;
     --no_jvm)               no_jvm=1 ;;
     --experimental)         experimental=1 ;;
     --c++11)                cpp11=1 ;;
@@ -177,6 +181,9 @@ if [ $no_openmp ]; then
 fi
 if [ $no_mpi ]; then
   NO_MPI=true
+fi
+if [ $no_tcmalloc ]; then
+  NO_TCMALLOC=true
 fi
 if [ $experimental ]; then
   EXPERIMENTAL=true
@@ -316,6 +323,9 @@ echo -e "\t NO_OPENMP=$NO_OPENMP" >> configure.deps
 echo -e "# Use MPI?  Without MPI GraphLab cannot run distributed: " >> configure.deps
 echo -e "\t NO_MPI=$NO_MPI" >> configure.deps
 
+echo -e "# Use tcmalloc?  Thread-Caching Malloc improves memory allocation: " >> configure.deps
+echo -e "\t NO_TCMALLOC=$NO_TCMALLOC" >> configure.deps
+
 echo -e "# The c compiler to use: " >> configure.deps
 echo -e "\t CC=$CC" >> configure.deps
 
@@ -354,6 +364,7 @@ cat configure.deps | tee -a $LOG_FILE
 ### Add addition config flags =================================================
 CFLAGS="$CFLAGS -D NO_OPENMP:BOOL=$NO_OPENMP"
 CFLAGS="$CFLAGS -D NO_MPI:BOOL=$NO_MPI"
+CFLAGS="$CFLAGS -D NO_TCMALLOC:BOOL=$NO_TCMALLOC"
 CFLAGS="$CFLAGS -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_DIR"
 CFLAGS="$CFLAGS -D EXPERIMENTAL:BOOL=$EXPERIMENTAL"
 CFLAGS="$CFLAGS -D CPP11:BOOL=$CPP11"


### PR DESCRIPTION
Hi!

Just strumbled on this problem and though I would help the next fellow mac user that comes by :-)

The commit is as follows:

For unknown reasons tcmalloc seems to not work properly on some
mac setups. The workaround until today is to manually edit [1](https://groups.google.com/d/msg/graphlab-kdd/SGfjqej1TqM/XTRMWg7946cJ)
CMakeLists.txt so that GraphLab is built without linking against
tcmalloc.

This patch introduces the `--no_tcmalloc` option to the configure
script (along with the CMake option -DNO_TCMALLOC) so that such
manual edits aren't really necessary when the user decides to
build GraphLab without tcmalloc.

Fixes #55. While I agree that the best approach would be to
actually fix the underlying problem, this patch enables mac
users facing the problem to work around the current issue more
easily.

NOTE: This is better viewed with the `-w` option to ignore the
indentation change incurred by adding the if()-endif() block.
