### PR TITLE
Enable use of implicit data in WALS

### DIFF
--- a/toolkits/collaborative_filtering/wals.cpp
+++ b/toolkits/collaborative_filtering/wals.cpp
@@ -602,6 +602,9 @@ int main(int argc, char** argv) {
   //                      "are in a different range allowing user 0 to connect to movie 0");
   clopts.attach_option("output", output_dir,
                        "Output results");
+
+  parse_implicit_command_line(clopts);
+
   if(!clopts.parse(argc, argv) || input_dir == "") {
     std::cout << "Error in parsing command line arguments." << std::endl;
     clopts.print_description();


### PR DESCRIPTION
Looks like this was just missing in wals.cpp; copied it in from als.cpp and it seems to work.
