### PR TITLE
Fixed kmeans to compile with C++11

### DIFF
--- a/toolkits/clustering/kmeans.cpp
+++ b/toolkits/clustering/kmeans.cpp
@@ -200,7 +200,7 @@ std::map<size_t, double>& plus_equal_vector(std::map<size_t, double>& a,
     if(a.find(id) != a.end()){
       a[id] += b.at(id);
     }else{
-      a.insert(std::make_pair<size_t, double>(id, val));
+      a.insert(std::make_pair(id, val));
     }
   }
   return a;
@@ -270,7 +270,7 @@ bool vertex_loader_sparse(graph_type& graph, const std::string& fname,
     if(pos > 0){
       size_t id = (size_t)std::atoi(t.substr(0, pos).c_str());
       double val = std::atof(t.substr(pos+1, t.length() - pos -1).c_str());
-      vtx.point_sparse.insert(std::make_pair<size_t, double>(id, val));
+      vtx.point_sparse.insert(std::make_pair(id, val));
     }
   }
   vtx.best_cluster = (size_t)(-1);
@@ -327,7 +327,7 @@ bool vertex_loader_with_id_sparse(graph_type& graph, const std::string& fname,
       if(pos > 0){
         size_t id = (size_t)std::atoi(t.substr(0, pos).c_str());
         double val = std::atof(t.substr(pos+1, t.length() - pos -1).c_str());
-        vtx.point_sparse.insert(std::make_pair<size_t, double>(id, val));
+        vtx.point_sparse.insert(std::make_pair(id, val));
       }
     }
   }


### PR DESCRIPTION
I only removed the parameters of make_pair which conflict with C++11 lvalue references.
