### PR TITLE
Minor compilation fixes and setting the number of threads for openmp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ endif()
 # OpenCV =================================================================
 ExternalProject_Add(opencv
   PREFIX ${GraphLab_SOURCE_DIR}/deps/opencv
-  URL http://superb-sea2.dl.sourceforge.net/project/opencvlibrary/opencv-unix/2.4.0/OpenCV-2.4.0.tar.bz2
+  URL http://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.4.0/OpenCV-2.4.0.tar.bz2/download
   # URL_MD5 010b63a2542c4ec4918c8cb431c00356
   PATCH_COMMAND patch -N -p0 cmake/OpenCVModule.cmake -i ${GraphLab_SOURCE_DIR}/patches/opencv_apple_rpath.patch || true
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>

--- a/src/graphlab/options/graphlab_options.hpp
+++ b/src/graphlab/options/graphlab_options.hpp
@@ -35,6 +35,8 @@
 #ifndef GRAPHLAB_GRAPHLAB_OPTIONS_HPP
 #define GRAPHLAB_GRAPHLAB_OPTIONS_HPP
 
+#include <omp.h>
+
 #include <graphlab/options/options_map.hpp>
  
 #include <graphlab/parallel/pthread_tools.hpp>
@@ -102,7 +104,7 @@ namespace graphlab {
 
 
     //! Set the number of cpus
-    void set_ncpus(size_t n) { ncpus = n; }
+    void set_ncpus(size_t n) { ncpus = n; omp_set_num_threads(ncpus);}
 
     //! Get the number of cpus
     size_t get_ncpus() const { return ncpus; }

--- a/src/graphlab/parallel/fiber_control.hpp
+++ b/src/graphlab/parallel/fiber_control.hpp
@@ -23,6 +23,8 @@
 
 #ifndef GRAPHLAB_FIBER_CONTROL_HPP
 #define GRAPHLAB_FIBER_CONTROL_HPP
+
+#include <stdint.h>
 #include <cstdlib>
 #include <boost/context/all.hpp>
 #include <boost/function.hpp>

--- a/src/graphlab/parallel/fiber_group.cpp
+++ b/src/graphlab/parallel/fiber_group.cpp
@@ -20,7 +20,6 @@
  *
  */
 
-
 #include <boost/bind.hpp>
 #include <graphlab/parallel/fiber_group.hpp>
 #include <graphlab/logger/assertions.hpp>

--- a/src/graphlab/util/hopscotch_table.hpp
+++ b/src/graphlab/util/hopscotch_table.hpp
@@ -24,6 +24,7 @@
 #ifndef GRAPHLAB_UTIL_HOPSCOTCH_TABLE_HPP
 #define GRAPHLAB_UTIL_HOPSCOTCH_TABLE_HPP
 
+#include <stdint.h>
 #include <vector>
 #include <utility>
 #include <algorithm>


### PR DESCRIPTION
As you already know, ncpus does not control the number of threads for those parts of graphlab that use openmp. This is a quick fix for that. 

I found several errors when compiling the complete code base and added fixes to some of them (includes in fiber_control.hpp and hopscotch_table.hpp and a change in the URL of openCV in Sourceforge). The includes   fixes problems which are resposibility of the boost libraries, but since they can be easily fixed from graphlab, I did. 

Still, there is an issue since quite a while when compiling the graph_analytics toolkit. It seems to come from one of the Spirit includes. I do not know how to fix that one.  
