### PR TITLE
adding a check for __NO_OPENMP__ so the code compiles on mac 10.9.5

### DIFF
--- a/src/graphlab/options/graphlab_options.hpp
+++ b/src/graphlab/options/graphlab_options.hpp
@@ -35,7 +35,9 @@
 #ifndef GRAPHLAB_GRAPHLAB_OPTIONS_HPP
 #define GRAPHLAB_GRAPHLAB_OPTIONS_HPP
 
+#ifndef __NO_OPENMP__
 #include <omp.h>
+#endif
 
 #include <graphlab/options/options_map.hpp>
  
@@ -104,7 +106,15 @@ namespace graphlab {
 
 
     //! Set the number of cpus
-    void set_ncpus(size_t n) { ncpus = n; omp_set_num_threads(ncpus);}
+    void set_ncpus(size_t n)
+      {
+#ifndef __NO_OPENMP__
+          ncpus = n;
+          omp_set_num_threads(ncpus);
+#else
+          ncpus = 1;
+#endif
+      }
 
     //! Get the number of cpus
     size_t get_ncpus() const { return ncpus; }


### PR DESCRIPTION
src/graphlab/graphlab_options.hpp:L38 should have been checking whether **NO_OPENMP** is defined (which it is on Macs because clang doesn't support it; not out of the box anyway). 

Code now compiles on Mac OS 10.9.5. 
