### PR TITLE
fix #167, make option ncpus work in linux.

### DIFF
--- a/src/graphlab/options/graphlab_options.hpp
+++ b/src/graphlab/options/graphlab_options.hpp
@@ -112,7 +112,7 @@ namespace graphlab {
           ncpus = n;
           omp_set_num_threads(ncpus);
 #else
-          ncpus = 1;
+          ncpus = n;
 #endif
       }
 


### PR DESCRIPTION
ncpus does not work if graphlab is configured with  `--no_openmp` option.

```
    void set_ncpus(size_t n)
      {
#ifndef __NO_OPENMP__
          ncpus = n;
          omp_set_num_threads(ncpus);
#else
          ncpus = n; // fix 
#endif
      }
```

This is a bug in graphlab.
This bug can be fixed by pull this request.
